### PR TITLE
Fix issue #27

### DIFF
--- a/inst/htmlwidgets/scatterplotThree.js
+++ b/inst/htmlwidgets/scatterplotThree.js
@@ -52,14 +52,13 @@ function render_init(el, width, height, choice, labelmargin)
   r.setSize(parseInt(width), parseInt(height));
   r.setClearColor("white");
     el.innerHTML = "";
-  el.appendChild(r.domElement);
   var coordLabel = document.createElement("div");
-  coordLabel.setAttribute("id","coordinate_label");
+  coordLabel.setAttribute("name","coordinate_label");
   coordLabel.style.zIndex = "100";
   coordLabel.style.position = "absolute";
-  coordLabel.style.top = "0";
   coordLabel.style.margin = labelmargin;
   el.appendChild(coordLabel);
+  el.appendChild(r.domElement);
 
   return r;
 }
@@ -363,7 +362,12 @@ function scatter(el, x, obj)
         label = intersects[0].object.name;
       }
     }
-    document.getElementById("coordinate_label").innerHTML = label;
+    //This actually synchronises all scatter plot labels, but I don't know how to 
+    //get a unique name 
+    var labels = document.getElementsByName("coordinate_label");
+    for(var i =0 ; i < labels.length ; i++){
+      labels[i].innerHTML = label;
+    }
   }
 
   function render()

--- a/inst/htmlwidgets/scatterplotThree.js
+++ b/inst/htmlwidgets/scatterplotThree.js
@@ -318,8 +318,8 @@ function scatter(el, x, obj)
     ev.preventDefault();
 
     var canvasRect = this.getBoundingClientRect();
-    mouse.x = 2 * ( ev.pageX - canvasRect.left ) / canvasRect.width - 1;
-    mouse.y = -2 * ( ev.pageY - canvasRect.top ) / canvasRect.height + 1;
+    mouse.x = 2 * ( ev.clientX - canvasRect.left ) / canvasRect.width - 1;
+    mouse.y = -2 * ( ev.clientY - canvasRect.top ) / canvasRect.height + 1;
 
     if (down) {
       var dx = ev.clientX - sx;


### PR DESCRIPTION
There are three minor fixes here around issue 27:

The first uses the client event coordinates, instead of the absolute page coordinates to fix the case where you scroll down the page, and  it no longer does point detection properly (because the offset are computed using just what's on the screen).

The second moves the label to be just above the chart rather than at the absolute top of the page. This means that if there is something on the page before the plot, the label text will still be with the chart.

The third causes all coordinate labels to update rather than just the first one on the page. This means that if you have more than one chart on a single html page, you can get mouse over text for all of them, rather than only the first. 