### PR TITLE
Support Shiny (Bootstrap) tabs

### DIFF
--- a/inst/htmlwidgets/scatterplotThree.js
+++ b/inst/htmlwidgets/scatterplotThree.js
@@ -175,6 +175,19 @@ Widget.scatter = function(w, h)
         _this.controls.handleResize();
         _this.animate();
        });
+
+      // ...and the same for bootstrap tabs
+      $('.nav-tabs a').on('shown.bs.tab', function(event){
+        if (event.target.hash == '#'+$(el).closest('.tab-pane')[0].id) {
+          _this.width = _this.el.offsetWidth;
+          _this.height = _this.el.offsetHeight;
+          _this.camera.aspect = _this.width / _this.height;
+          _this.camera.updateProjectionMatrix();
+          _this.renderer.setSize(_this.width, _this.height);
+          _this.controls.handleResize();
+          _this.animate();
+        }
+       });
     }
 
     el.onmousemove = function(ev)


### PR DESCRIPTION
Handle Bootstrap tabs, the same way slides are handled (by subscribing to "shown" events). Use the following as a test:

``` R
library("shiny")
library("threejs")

plot.statistics <- function(n)
{
  x_data <- runif(1000)
  y_data <- runif(1000)
  z_data <- x_data^n + y_data^n
  
  ui <- fluidPage(
    title = "x-y-z",
    fluidRow(column(width = 12, scatterplot3js(x = x_data,
                                               y = y_data,
                                               z = z_data,
                                               color = rainbow(length(z_data)),
                                               pch = ".",
                                               size = 0.2,
                                               labels = paste(z_data, " @ ", x_data, "_", y_data, sep = ""),
                                               axisLabels = c("x", "z", "y"),
                                               cex.lab = 0.2,
                                               cex.axis = 0.2,
                                               main = "x-y-z"))))
  
  return(list("tab.title" = paste("Surface ", n, sep = ""),
              "tab.content" = ui))
}

tabs <- mapply(plot.statistics,
               n = c(1, 2, 3),
               SIMPLIFY = FALSE,
               USE.NAMES = FALSE)

tabPanels <- lapply(seq_len(length(tabs)), function(i) tabPanel(tabs[[i]]$tab.title, tabs[[i]]$tab.content))

ui <- fluidPage(title = "3d dynamic plots", mainPanel(do.call(tabsetPanel, tabPanels)))

browseURL(htmltools:::html_print(ui))
```