### PR TITLE
stuff.camera.aspect is not updated when the window size is changed

### DIFF
--- a/inst/htmlwidgets/globe.js
+++ b/inst/htmlwidgets/globe.js
@@ -32,6 +32,7 @@ HTMLWidgets.widget(
     stuff.height = height;
     var ymax = stuff.camera.near * Math.tan((Math.PI / 180) * stuff.camera.fov * 0.5);
     var ymin = - ymax;
+    stuff.camera.aspect = width / height;
     var xmin = ymin * stuff.camera.aspect;
     var xmax = ymax * stuff.camera.aspect;
     stuff.camera.projectionMatrix = new THREE.Matrix4().makePerspective(xmin, xmax, ymax, ymin, stuff.camera.near, stuff.camera.far);


### PR DESCRIPTION
Hi @bwlewis,

I had an issue when using `globejs()`. The rendered object is rendered in a wrong scale once the browser window size is changed. It is due to `stuff.camera.aspect` wasn't updated in `resize()`. 

Kun